### PR TITLE
Fixed test_xyincrease_false_changes_axes flaky test

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -2398,6 +2398,7 @@ class TestAxesKwargs:
         da.plot(ylim=[0, 1000])
         expected = (0.0, 1000.0)
         assert plt.gca().get_ylim() == expected
+        plt.clf()
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_xticks_kwarg(self, da):


### PR DESCRIPTION
Test `testxyincrease_false_changes_axes` is flaky in nature.

TestCase passes consistently in the actual order with command:
```
pytest tests/test_plot.py
```

TestCase fails when one randomises the order in *test_plot.py* module by using the plugin [pytest-random-order](https://pypi.org/project/pytest-random-order/) with command:
```
pytest tests/test_plot.py --random-order-seed=802425 -v
```

The victim `test_xyincrease_false_changes_axes` fails in a failing test order because there is at least one test that runs before the victim and “pollutes” the state (e.g., global state: here, it is `matplotlib's plt`) on which the victim depends. [(Paper)](https://taoxie.cs.illinois.edu/publications/esecfse19-ifixflakies.pdf)

After investigation, we found the polluter test to be *test_ylim_kwarg*

Potential Fix: Adding a `plt.clf` or `plt.cla` at the end of the polluter test. Let us know your preference.

Please let us know if you require the pass and fail logs.

Also, if one runs test_plot.py in any random order, Teardown phase throws an error which is raised by test_all_figures_closed(). 
Should I raise a separate PR for the same?

Contributors:
[Yash Saboo](https://github.com/yashsaboo)
[Nirupam K N](https://github.com/Nirupamkn)