### PR TITLE
Fixed 10 Polluters Tests by replacing plt.clf() instances with figure_context()

### DIFF
--- a/xarray/tests/test_plot.py
+++ b/xarray/tests/test_plot.py
@@ -316,9 +316,9 @@ class TestPlot(PlotTestCase):
         hdl = da.plot.line(x="lon", hue="x")
         assert len(hdl) == 5
 
-        plt.clf()
-        hdl = da.plot.line(x="lon", hue="y")
-        assert len(hdl) == 4
+        with figure_context():
+            hdl = da.plot.line(x="lon", hue="y")
+            assert len(hdl) == 4
 
         with pytest.raises(ValueError, match="For 2D inputs, hue must be a dimension"):
             da.plot.line(x="lon", hue="lat")
@@ -1760,10 +1760,10 @@ class TestImshow(Common2dMixin, PlotTestCase):
         assert plt.xlim()[0] < 0
         assert plt.ylim()[1] < 0
 
-        plt.clf()
-        da.plot.imshow(origin="lower")
-        assert plt.xlim()[0] < 0
-        assert plt.ylim()[0] < 0
+        with figure_context():
+            da.plot.imshow(origin="lower")
+            assert plt.xlim()[0] < 0
+            assert plt.ylim()[0] < 0
 
 
 class TestFacetGrid(PlotTestCase):
@@ -2358,61 +2358,60 @@ class TestAxesKwargs:
     @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("xincrease", [True, False])
     def test_xincrease_kwarg(self, da, xincrease):
-        plt.clf()
-        da.plot(xincrease=xincrease)
-        assert plt.gca().xaxis_inverted() == (not xincrease)
+        with figure_context():
+            da.plot(xincrease=xincrease)
+            assert plt.gca().xaxis_inverted() == (not xincrease)
 
     @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("yincrease", [True, False])
     def test_yincrease_kwarg(self, da, yincrease):
-        plt.clf()
-        da.plot(yincrease=yincrease)
-        assert plt.gca().yaxis_inverted() == (not yincrease)
+        with figure_context():
+            da.plot(yincrease=yincrease)
+            assert plt.gca().yaxis_inverted() == (not yincrease)
 
     @pytest.mark.parametrize("da", test_da_list)
     @pytest.mark.parametrize("xscale", ["linear", "log", "logit", "symlog"])
     def test_xscale_kwarg(self, da, xscale):
-        plt.clf()
-        da.plot(xscale=xscale)
-        assert plt.gca().get_xscale() == xscale
+        with figure_context():
+            da.plot(xscale=xscale)
+            assert plt.gca().get_xscale() == xscale
 
     @pytest.mark.parametrize(
         "da", [DataArray(easy_array((10,))), DataArray(easy_array((10, 3)))]
     )
     @pytest.mark.parametrize("yscale", ["linear", "log", "logit", "symlog"])
     def test_yscale_kwarg(self, da, yscale):
-        plt.clf()
-        da.plot(yscale=yscale)
-        assert plt.gca().get_yscale() == yscale
+        with figure_context():
+            da.plot(yscale=yscale)
+            assert plt.gca().get_yscale() == yscale
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_xlim_kwarg(self, da):
-        plt.clf()
-        expected = (0.0, 1000.0)
-        da.plot(xlim=[0, 1000])
-        assert plt.gca().get_xlim() == expected
+        with figure_context():
+            expected = (0.0, 1000.0)
+            da.plot(xlim=[0, 1000])
+            assert plt.gca().get_xlim() == expected
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_ylim_kwarg(self, da):
-        plt.clf()
-        da.plot(ylim=[0, 1000])
-        expected = (0.0, 1000.0)
-        assert plt.gca().get_ylim() == expected
-        plt.clf()
+        with figure_context():
+            da.plot(ylim=[0, 1000])
+            expected = (0.0, 1000.0)
+            assert plt.gca().get_ylim() == expected
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_xticks_kwarg(self, da):
-        plt.clf()
-        da.plot(xticks=np.arange(5))
-        expected = np.arange(5).tolist()
-        assert_array_equal(plt.gca().get_xticks(), expected)
+        with figure_context():
+            da.plot(xticks=np.arange(5))
+            expected = np.arange(5).tolist()
+            assert_array_equal(plt.gca().get_xticks(), expected)
 
     @pytest.mark.parametrize("da", test_da_list)
     def test_yticks_kwarg(self, da):
-        plt.clf()
-        da.plot(yticks=np.arange(5))
-        expected = np.arange(5)
-        assert_array_equal(plt.gca().get_yticks(), expected)
+        with figure_context():
+            da.plot(yticks=np.arange(5))
+            expected = np.arange(5)
+            assert_array_equal(plt.gca().get_yticks(), expected)
 
 
 @requires_matplotlib


### PR DESCRIPTION
As suggested by [Mathias](https://github.com/mathause), we replaced all `plt.clf()` instances with `figure_context()` which correctly closes all graphs and made other test cases non-flaky. The polluters which were fixed are:
- test_2d_coords_line_plot
- test_origin_overrides_xyincrease
- test_xincrease_kwarg
- test_yincrease_kwarg
- test_xscale_kwarg
- test_yscale_kwarg
- test_xlim_kwarg
- test_ylim_kwarg
- test_xticks_kwarg
- test_yticks_kwarg

This PR also fixed the teardown phase problem. Hence, `test_all_figures_closed()` successfully passes.